### PR TITLE
Make statements gender-neutral

### DIFF
--- a/threesixty-statements.csv
+++ b/threesixty-statements.csv
@@ -1,6 +1,6 @@
 statement,attribute,connotation
-exhibits leadership qualities in his position,collaboration,1
-knows his own weaknesses,professionalism,1
+exhibits leadership qualities,collaboration,1
+knows their own weaknesses,professionalism,1
 appears to meetings on time,professionalism,1
 delivers high quality work,professionalism,1
 is pragmatic,proficiency,1
@@ -9,8 +9,8 @@ rushes decisions,professionalism,0
 avoids decisions,professionalism,0
 values other people's opinions,collaboration,1
 offers help to others,collaboration,1
-takes responsibility for his actions,professionalism,1
-speaks his mind,collaboration,1
+takes responsibility for their actions,professionalism,1
+speaks their mind,collaboration,1
 does reviews on time,professionalism,1
 does careful reviews,professionalism,1
 takes time to answer questions,professionalism,1
@@ -20,20 +20,20 @@ communicates well,collaboration,1
 is organized,professionalism,1
 is open to feedback,professionalism,1
 acts responsibly,professionalism,1
-can execute his tasks independently,proficiency,1
+performs tasks independently,proficiency,1
 keeps promises,professionalism,1
 cares about quality,proficiency,1
 treats others with respect,collaboration,1
 actively participates in group meetings,collaboration,1
 apologizes for failures,collaboration,1
-communicates his actions well,proficiency,1
+communicates their actions well,proficiency,1
 is someone I can learn from,proficiency,1
 is a role model,professionalism,1
 is smart,proficiency,1
 works fast,proficiency,1
 is friendly,collaboration,1
 is a good employee,proficiency,1
-can execute a decision that isn't his own,collaboration,1
+can execute decisions made by others,collaboration,1
 respects other people's opinions,collaboration,1
 is a voice for reason,collaboration,1
 speaks in understandable terms,professionalism,1
@@ -52,7 +52,7 @@ can communicate a clear vision,proficiency,1
 thinks in strategic milestones instead of short-term goals,proficiency,1
 is good at coaching others,collaboration,1
 is able to start and stop tasks quickly,proficiency,1
-has passion for his work,professionalism,1
+has passion for their work,professionalism,1
 pays attention to detail,proficiency,1
 finds innovative solutions to problems,proficiency,1
 can lead a discussion,collaboration,1


### PR DESCRIPTION
360 statements should be gender neutral!

I dropped pronouns whenever I found a better alternative that I thought didn't change the meaning. Otherwise, I switched to [singular they][], because it seems to get more and more [traction][] and is the easiest fix.

Feel free to improve on my changes!

[singular they]: https://en.wikipedia.org/wiki/Singular_they
[traction]: https://www.washingtonpost.com/news/morning-mix/wp/2017/03/28/the-singular-gender-neutral-they-added-to-the-associated-press-stylebook/